### PR TITLE
Set the "-Z build-std" option when calling "cargo build"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
+extern crate cargo_metadata;
 extern crate linkle;
 extern crate serde;
 extern crate serde_json;
-extern crate cargo_metadata;
 
 #[macro_use]
 extern crate serde_derive;
@@ -9,26 +9,28 @@ extern crate serde_derive;
 #[macro_use]
 extern crate clap;
 
+use clap::{App, AppSettings, Arg, SubCommand};
 use std::env;
 use std::fs::{File, OpenOptions};
-use std::path::{PathBuf, Path};
-use std::process::{Command, Stdio};
 use std::io::BufReader;
-use clap::{Arg, AppSettings, App, SubCommand};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
-use cargo_metadata::{Artifact, Message, Package, MetadataCommand};
-use linkle::format::{nacp::NacpFile, nxo::NxoFile, romfs::RomFs, pfs0::Pfs0, npdm::NpdmJson, npdm::ACIDBehavior};
+use cargo_metadata::{Artifact, Message, MetadataCommand, Package};
+use linkle::format::{
+    nacp::NacpFile, npdm::ACIDBehavior, npdm::NpdmJson, nxo::NxoFile, pfs0::Pfs0, romfs::RomFs,
+};
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 struct NspMetadata {
-    npdm: String
+    npdm: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 struct NroMetadata {
     romfs: Option<String>,
     icon: Option<String>,
-    nacp: Option<NacpFile>
+    nacp: Option<NacpFile>,
 }
 
 const DEFAULT_TARGET_TRIPLE: &str = "aarch64-none-elf";
@@ -44,7 +46,7 @@ fn prepare_default_target(root: &str) -> String {
 
     std::fs::write(json, DEFAULT_TARGET_JSON.replace("$LD_PATH", ld.as_str())).unwrap();
     std::fs::write(ld, DEFAULT_TARGET_LD.to_string()).unwrap();
-    
+
     target_path
 }
 
@@ -58,25 +60,32 @@ fn handle_nro_format(root: &Path, artifact: &Artifact, metadata: NroMetadata) {
     let elf = artifact.filenames[0].clone();
     let nro = get_output_elf_path_as(artifact, "nro");
 
-    let romfs = metadata.romfs.as_ref().map(|romfs_dir| RomFs::from_directory(&root.join(romfs_dir)).unwrap());
-    let icon = metadata.icon.as_ref().map(|icon_file| root.join(icon_file.clone())).map(|icon_path| icon_path.to_string_lossy().into_owned());
+    let romfs = metadata
+        .romfs
+        .as_ref()
+        .map(|romfs_dir| RomFs::from_directory(&root.join(romfs_dir)).unwrap());
+    let icon = metadata
+        .icon
+        .as_ref()
+        .map(|icon_file| root.join(icon_file.clone()))
+        .map(|icon_path| icon_path.to_string_lossy().into_owned());
 
     NxoFile::from_elf(elf.to_str().unwrap())
-    .unwrap()
-    .write_nro(
-        &mut File::create(nro.clone()).unwrap(),
-        romfs,
-        icon.as_ref().map(|icon_path| icon_path.as_str()),
-        metadata.nacp,
-    )
-    .unwrap();
+        .unwrap()
+        .write_nro(
+            &mut File::create(nro.clone()).unwrap(),
+            romfs,
+            icon.as_ref().map(|icon_path| icon_path.as_str()),
+            metadata.nacp,
+        )
+        .unwrap();
 
     println!("Built {}", nro.to_string_lossy());
 }
 
 fn handle_nsp_format(root: &Path, artifact: &Artifact, metadata: NspMetadata) {
     let elf = artifact.filenames[0].clone();
-    
+
     let output_path = elf.parent().unwrap();
     let exefs_dir = output_path.join("exefs");
     let _ = std::fs::remove_dir_all(exefs_dir.clone());
@@ -91,10 +100,16 @@ fn handle_nsp_format(root: &Path, artifact: &Artifact, metadata: NspMetadata) {
     let npdm = NpdmJson::from_file(&npdm_json).unwrap();
     let mut option = OpenOptions::new();
     let output_option = option.write(true).create(true).truncate(true);
-    let mut out_file = output_option.open(main_npdm.clone()).map_err(|err| (err, main_npdm.clone())).unwrap();
+    let mut out_file = output_option
+        .open(main_npdm.clone())
+        .map_err(|err| (err, main_npdm.clone()))
+        .unwrap();
     npdm.into_npdm(&mut out_file, ACIDBehavior::Empty).unwrap();
 
-    NxoFile::from_elf(elf.to_str().unwrap()).unwrap().write_nso(&mut File::create(main_exe.clone()).unwrap()).unwrap();
+    NxoFile::from_elf(elf.to_str().unwrap())
+        .unwrap()
+        .write_nso(&mut File::create(main_exe.clone()).unwrap())
+        .unwrap();
 
     let mut nsp = Pfs0::from_directory(exefs_dir.to_str().unwrap()).unwrap();
     let mut option = OpenOptions::new();
@@ -102,9 +117,11 @@ fn handle_nsp_format(root: &Path, artifact: &Artifact, metadata: NspMetadata) {
     nsp.write_pfs0(
         &mut output_option
             .open(exefs_nsp.clone())
-            .map_err(|err| (err, exefs_nsp.clone())).unwrap(),
+            .map_err(|err| (err, exefs_nsp.clone()))
+            .unwrap(),
     )
-    .map_err(|err| (err, exefs_nsp.clone())).unwrap();
+    .map_err(|err| (err, exefs_nsp.clone()))
+    .unwrap();
 
     println!("Built {}", exefs_nsp.to_string_lossy());
 }
@@ -113,40 +130,51 @@ fn main() {
     let matches = App::new(crate_name!())
         .version(concat!("v", crate_version!()))
         .bin_name("cargo")
-        .settings(&[AppSettings::GlobalVersion,
-            AppSettings::SubcommandRequired])
-        .subcommand(SubCommand::with_name("nx")
-            .author(crate_authors!(""))
-            .about(crate_description!())
-            .arg(Arg::with_name("release")
-                .short("r")
-                .long("release")
-                .help("Builds on release profile")
-                .required(false))
-            .arg(Arg::with_name("path")
-                .short("p")
-                .long("path")
-                .value_name("DIR")
-                .help("Sets a custom path")
-                .required(false)
-                .takes_value(true))
-            .arg(Arg::with_name("triple")
-                .short("tp")
-                .long("triple")
-                .value_name("TRIPLE")
-                .help("Sets a custom target triple")
-                .required(false)
-                .takes_value(true))
-            .arg(Arg::with_name("use-custom-target")
-                .short("ctg")
-                .long("use-custom-target")
-                .help("Avoids using the default target files")
-                .required(false))
-            .arg(Arg::with_name("verbose")
-                .short("v")
-                .long("verbose")
-                .help("Displays extra information during the build process")
-                .required(false)))
+        .settings(&[AppSettings::GlobalVersion, AppSettings::SubcommandRequired])
+        .subcommand(
+            SubCommand::with_name("nx")
+                .author(crate_authors!(""))
+                .about(crate_description!())
+                .arg(
+                    Arg::with_name("release")
+                        .short("r")
+                        .long("release")
+                        .help("Builds on release profile")
+                        .required(false),
+                )
+                .arg(
+                    Arg::with_name("path")
+                        .short("p")
+                        .long("path")
+                        .value_name("DIR")
+                        .help("Sets a custom path")
+                        .required(false)
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("triple")
+                        .short("tp")
+                        .long("triple")
+                        .value_name("TRIPLE")
+                        .help("Sets a custom target triple")
+                        .required(false)
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("use-custom-target")
+                        .short("ctg")
+                        .long("use-custom-target")
+                        .help("Avoids using the default target files")
+                        .required(false),
+                )
+                .arg(
+                    Arg::with_name("verbose")
+                        .short("v")
+                        .long("verbose")
+                        .help("Displays extra information during the build process")
+                        .required(false),
+                ),
+        )
         .get_matches();
 
     let nx_matches = matches.subcommand_matches("nx").unwrap();
@@ -155,15 +183,18 @@ fn main() {
 
     let is_release = nx_matches.is_present("release");
     if is_verbose {
-        println!("Profile: {}", match is_release {
-            true => "release",
-            false => "dev"
-        });
+        println!(
+            "Profile: {}",
+            match is_release {
+                true => "release",
+                false => "dev",
+            }
+        );
     }
 
     let path = match nx_matches.value_of("path") {
         Some(path_str) => path_str,
-        None => "."
+        None => ".",
     };
 
     let metadata = MetadataCommand::new()
@@ -178,25 +209,22 @@ fn main() {
     let is_nro = metadata_v.pointer("/nx/nro").is_some();
     if is_nsp && is_nro {
         panic!("Error: multiple target formats are not yet supported...");
-    }
-    else if is_nsp {
+    } else if is_nsp {
         println!("Compiling and generating NSP...");
-    }
-    else if is_nro {
+    } else if is_nro {
         println!("Compiling and generating NRO...");
-    }
-    else {
+    } else {
         println!("No target formats were found in Cargo.toml...");
     }
 
     let rust_target_path = match env::var("RUST_TARGET_PATH") {
         Ok(s) => PathBuf::from(s),
-        Err(_) => metadata.workspace_root.clone()
+        Err(_) => metadata.workspace_root.clone(),
     };
 
     let triple = match nx_matches.value_of("triple") {
         Some(triple_str) => triple_str,
-        None => DEFAULT_TARGET_TRIPLE
+        None => DEFAULT_TARGET_TRIPLE,
     };
     if is_verbose {
         println!("Triple: {}", triple);
@@ -218,7 +246,7 @@ fn main() {
     let mut build_args: Vec<String> = vec![
         String::from("build"),
         format!("--target={}", triple),
-        String::from("--message-format=json-diagnostic-rendered-ansi")
+        String::from("--message-format=json-diagnostic-rendered-ansi"),
     ];
     if is_release {
         build_args.push(String::from("--release"));
@@ -231,25 +259,34 @@ fn main() {
         .current_dir(path)
         .spawn()
         .unwrap();
-    
+
     let reader = BufReader::new(command.stdout.take().unwrap());
     for message in Message::parse_stream(reader) {
         match message {
             Ok(Message::CompilerArtifact(ref artifact)) => {
-                if artifact.target.kind.contains(&"bin".into()) || artifact.target.kind.contains(&"cdylib".into()) {
-                    let package: &Package = match metadata.packages.iter().find(|v| v.id == artifact.package_id) {
+                if artifact.target.kind.contains(&"bin".into())
+                    || artifact.target.kind.contains(&"cdylib".into())
+                {
+                    let package: &Package = match metadata
+                        .packages
+                        .iter()
+                        .find(|v| v.id == artifact.package_id)
+                    {
                         Some(v) => v,
                         None => continue,
                     };
-    
+
                     let root = package.manifest_path.parent().unwrap();
-    
+
                     if is_nsp {
-                        let nsp_metadata: NspMetadata = serde_json::from_value(metadata_v.pointer("/nx/nsp").cloned().unwrap()).unwrap_or_default();
+                        let nsp_metadata: NspMetadata =
+                            serde_json::from_value(metadata_v.pointer("/nx/nsp").cloned().unwrap())
+                                .unwrap_or_default();
                         handle_nsp_format(root, artifact, nsp_metadata);
-                    }
-                    else if is_nro {
-                        let nro_metadata: NroMetadata = serde_json::from_value(metadata_v.pointer("/nx/nro").cloned().unwrap()).unwrap_or_default();
+                    } else if is_nro {
+                        let nro_metadata: NroMetadata =
+                            serde_json::from_value(metadata_v.pointer("/nx/nro").cloned().unwrap())
+                                .unwrap_or_default();
                         handle_nro_format(root, artifact, nro_metadata);
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -245,6 +245,10 @@ fn main() {
 
     let mut build_args: Vec<String> = vec![
         String::from("build"),
+        // TODO: consider explicitly setting which crates to compile (e.g.
+        // build-std=core,std,alloc,proc_macro,test).
+        String::from("-Z"),
+        String::from("build-std"),
         format!("--target={}", triple),
         String::from("--message-format=json-diagnostic-rendered-ansi"),
     ];


### PR DESCRIPTION
> Let me start by stating that this is my first time meddling with `no_std` and custom targets, so I might've gotten some stuff wrong in which case I'd appreciate some enlightenment.

I couldn't get any of the examples to build using `cargo-nx`, so I did some research and I found out that I was missing two things:

1. `build-std` is only available on `nightly` (and I was initially trying to use stable),
2. `-Z build-std` is needed for `cargo build` to compile `core` for the custom targets[^1].

While the former was an easy fix, I wasn't too sure how to approach the latter as `cargo-nx` has no system in place to propagate arguments to the underlying `cargo build` call.

@XorTroll from what I can see in [XorTroll/emuiibo](https://github.com/XorTroll/emuiibo) you provide `emuiibo/.cargo/config.toml` file with the necessary settings but that doesn't seem to be the case for all the projects in this org.

PS: the diff is mostly `rustfmt` running (commit 188435a3c6cefb5f893fdb565dd09ac683cd8562), the only real changes I made are in commit be06398fe46aaa51e887b915d481241275cd63ed.

PPS: there are some changes I'd like to make to how arguments are parsed (mostly refactoring stuff, possibly allowing setting flags for the underlying `cargo build` command), would you be interested in this?

[^1]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std