### PR TITLE
Use Clap 3 with derives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,15 +64,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,17 +259,41 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -461,6 +476,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,6 +501,16 @@ name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+
+[[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg 1.1.0",
+ "hashbrown 0.12.1",
+]
 
 [[package]]
 name = "itoa"
@@ -667,8 +704,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c672c7ad9ec066e428c00eb917124a06f08db19e2584de982cc34b1f4c12485"
 dependencies = [
  "dlv-list",
- "hashbrown",
+ "hashbrown 0.9.1",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "pem"
@@ -707,6 +750,30 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -961,9 +1028,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -995,13 +1062,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "termcolor"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
- "unicode-width",
+ "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -1042,22 +1115,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -1086,6 +1147,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["XorTroll"]
 license = "MIT"
 homepage = "https://github.com/aarch64-switch-rs/"
 repository = "https://github.com/aarch64-switch-rs/cargo-nx/"
-edition = "2018"
+edition = "2021"
 description = "Cargo subcommand to simplify creating and building Nintendo Switch homebrew projects"
 
 [dependencies]
-clap = "2"
+clap = { version = "3", features = ["derive"] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Available parameters/flags
 
 - `--edition`: Specify the package edition (available editions: [2015, 2018, 2021], default is 2021)
 
-- `--lib`, `--nro`, `--nsp`: Via one of these one can specify the package kind to create (default is NRO)
+- `--type <package type>`: Specify the package type to create. `lib`, `nro`, and `nsp` are available, with `nro` being the default.
 
 ### `build` subcommand
 
@@ -50,9 +50,9 @@ Available parameters/flags:
 
 - `-p <path>`, `--path=<path>`: Specifies a path with a crate to build (containing `Cargo.toml`, etc.), since the current directory is used by default otherwise.
 
-- `-tp <triple>`, `--triple=<triple>`: Specifies the target triple, which is "aarch64-none-elf" by default.
+- `-t <triple>`, `--triple=<triple>`: Specifies the target triple, which is "aarch64-none-elf" by default.
 
-- `-ctg`, `--use-custom-target`: Notifies the program to not use the default target JSON/linker script, which can be used to use custom ones.
+- `-c`, `--use-custom-target`: Notifies the program to not use the default target JSON/linker script, which can be used to use custom ones.
 
 - `-v`, `--verbose`: Displays extra information during the build process.
 
@@ -87,32 +87,32 @@ nacp = { name = "Sample project", author = "XorTroll", version = "0.1 beta" }
 
 The fields present on the `nacp` object, all of them optional, are the following:
 
-| Field             | Description                                       | Default value              |
-|:----------------- |:-------------------------------------------------:| --------------------------:|
-| name              | The application name                              | Unknown Application        |
-| author            | The application author                            | Unknown Author             |
-| version           | The application version                           | 1.0.0                      |
-| title_id          | The application ID                                | 0000000000000000           |
-| dlc_base_title_id | The base ID of all the application's DLC          | title_id + 0x1000          |
+| Field             |                    Description                    |              Default value |
+| :---------------- | :-----------------------------------------------: | -------------------------: |
+| name              |               The application name                |        Unknown Application |
+| author            |              The application author               |             Unknown Author |
+| version           |              The application version              |                      1.0.0 |
+| title_id          |                The application ID                 |           0000000000000000 |
+| dlc_base_title_id |     The base ID of all the application's DLC      |          title_id + 0x1000 |
 | lang (object)     | Different names/authors depending of the language | values above for all langs |
 
-| Language codes      | Corresponding names    |
-|:-------------------:|:----------------------:|
-| en-US               | American English       |
-| en-GB               | British English        |
-| ja                  | Japanese               |
-| fr                  | French                 |
-| de                  | German                 |
-| es-419              | Latin-American Spanish |
-| es                  | Spanish                |
-| it                  | Italian                |
-| nl                  | Dutch                  |
-| fr-CA               | Canadian French        |
-| pt                  | Portuguese             |
-| ru                  | Russian                |
-| ko                  | Korean                 |
-| zh-TW               | Chinese (Traditional)  |
-| zh-CN               | Chinese (Simplified)   |
+| Language codes |  Corresponding names   |
+| :------------: | :--------------------: |
+|     en-US      |    American English    |
+|     en-GB      |    British English     |
+|       ja       |        Japanese        |
+|       fr       |         French         |
+|       de       |         German         |
+|     es-419     | Latin-American Spanish |
+|       es       |        Spanish         |
+|       it       |        Italian         |
+|       nl       |         Dutch          |
+|     fr-CA      |    Canadian French     |
+|       pt       |       Portuguese       |
+|       ru       |        Russian         |
+|       ko       |         Korean         |
+|     zh-TW      | Chinese (Traditional)  |
+|     zh-CN      |  Chinese (Simplified)  |
 
 - Example with specific languages:
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,89 @@
+use clap::{builder::PossibleValuesParser, Args, Parser, Subcommand};
+use std::{fmt, path::PathBuf};
+
+/// The supported Rust editions
+pub static SUPPORTED_EDITIONS: &[&str] = &["2015", "2018", "2021"];
+/// Which Rust edition to use by default
+pub static DEFAULT_EDITION: &str = "2021";
+/// Which package type to use by default
+pub static DEFAULT_PACKAGE_TYPE: &str = "nro";
+
+#[derive(Parser)]
+#[clap(name = "cargo", bin_name = "cargo")]
+pub enum Cargo {
+    Nx(CargoNxArgs),
+}
+
+#[derive(Args)]
+#[clap(author, version, about)]
+pub struct CargoNxArgs {
+    #[clap(subcommand)]
+    pub subcommand: CargoNxSubcommand,
+}
+
+#[derive(Subcommand)]
+pub enum CargoNxSubcommand {
+    New(CargoNxNew),
+    Build(CargoNxBuild),
+}
+
+#[derive(Args)]
+#[clap(about = "Create a new Rust project for the Nintendo Switch")]
+pub struct CargoNxNew {
+    /// Select the package type that will be built by this project.
+    #[clap(short = 't', long = "type", value_enum, default_value = DEFAULT_PACKAGE_TYPE)]
+    pub kind: PackageKind,
+    /// Set the Rust edition to use.
+    #[clap(short, long, value_parser = PossibleValuesParser::new(SUPPORTED_EDITIONS), default_value = DEFAULT_EDITION)]
+    pub edition: String,
+    /// Set the name of the newly created package.
+    /// The path directory name is used by default.
+    #[clap(short, long)]
+    pub name: Option<String>,
+    /// The path where the new package will be created
+    #[clap(value_parser, value_name = "DIR")]
+    pub path: PathBuf,
+}
+
+#[derive(Args)]
+#[clap(about = "Build a Rust project for the Nintendo Switch")]
+pub struct CargoNxBuild {
+    /// Builds using the release profile.
+    #[clap(short, long)]
+    pub release: bool,
+    /// The path to the project to build.
+    #[clap(short, long, default_value = ".", value_name = "DIR", value_parser)]
+    pub path: PathBuf,
+    /// The custom target triple to use, if any.
+    #[clap(short, long)]
+    pub triple: Option<String>,
+    /// Avoids using the default target files.
+    #[clap(short = 'c', long)]
+    pub use_custom_target: bool,
+    /// Displays extra information during the build process.
+    #[clap(short, long)]
+    pub verbose: bool,
+    /// Compiles as 32-bit default target, rather than the default 64-bit target.
+    #[clap(long)]
+    pub arm: bool,
+}
+
+#[derive(Debug, Copy, Clone, ValueEnum)]
+#[clap(rename_all = "lower")]
+pub enum PackageKind {
+    Lib,
+    Nro,
+    Nsp,
+}
+
+impl fmt::Display for PackageKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let fmt_str = match self {
+            PackageKind::Lib => "lib",
+            PackageKind::Nro => "nro",
+            PackageKind::Nsp => "nsp",
+        };
+
+        write!(f, "{}", fmt_str)
+    }
+}

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,23 +1,29 @@
+use crate::args::CargoNxBuild;
+use cargo_metadata::{Artifact, Message, MetadataCommand, Package};
+use linkle::format::{
+    nacp::Nacp,
+    npdm::{AcidBehavior, Npdm},
+    nxo::Nxo,
+    pfs0::Pfs0,
+    romfs::RomFs,
+};
 use std::env;
 use std::fs::{File, OpenOptions};
-use std::path::{PathBuf, Path};
-use std::process::{Command, Stdio};
 use std::io::BufReader;
-use clap::ArgMatches;
-use cargo_metadata::{Artifact, Message, Package, MetadataCommand};
-use linkle::format::{nacp::Nacp, nxo::Nxo, romfs::RomFs, pfs0::Pfs0, npdm::{Npdm, AcidBehavior}};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 struct NspMetadata {
     npdm: Option<Npdm>,
-    npdm_json: Option<String>
+    npdm_json: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 struct NroMetadata {
     romfs: Option<String>,
     icon: Option<String>,
-    nacp: Option<Nacp>
+    nacp: Option<Nacp>,
 }
 
 // Note: when the tier 3 target gets added (https://github.com/rust-lang/rust/pull/88991), we will no longer need to manually include/write these for building
@@ -34,8 +40,7 @@ const DEFAULT_TARGET_LD_32: &str = include_str!("../default/specs/armv7-nintendo
 const fn get_default_target_triple(is_32bit: bool) -> &'static str {
     if is_32bit {
         DEFAULT_TARGET_TRIPLE_32
-    }
-    else {
+    } else {
         DEFAULT_TARGET_TRIPLE_64
     }
 }
@@ -44,8 +49,7 @@ const fn get_default_target_triple(is_32bit: bool) -> &'static str {
 const fn get_default_target_json(is_32bit: bool) -> &'static str {
     if is_32bit {
         DEFAULT_TARGET_JSON_32
-    }
-    else {
+    } else {
         DEFAULT_TARGET_JSON_64
     }
 }
@@ -54,8 +58,7 @@ const fn get_default_target_json(is_32bit: bool) -> &'static str {
 const fn get_default_target_ld(is_32bit: bool) -> &'static str {
     if is_32bit {
         DEFAULT_TARGET_LD_32
-    }
-    else {
+    } else {
         DEFAULT_TARGET_LD_64
     }
 }
@@ -64,12 +67,20 @@ fn prepare_default_target(root: &str, is_32bit: bool) -> String {
     let target_path = format!("{}/target", root);
     std::fs::create_dir_all(target_path.clone()).unwrap();
 
-    let json = format!("{}/{}.json", target_path, get_default_target_triple(is_32bit));
+    let json = format!(
+        "{}/{}.json",
+        target_path,
+        get_default_target_triple(is_32bit)
+    );
     let ld = format!("{}/{}.ld", target_path, get_default_target_triple(is_32bit));
 
-    std::fs::write(json, get_default_target_json(is_32bit).replace("<ld_path>", ld.as_str())).unwrap();
-    std::fs::write(ld, get_default_target_ld(is_32bit).to_string()).unwrap();
-    
+    std::fs::write(
+        json,
+        get_default_target_json(is_32bit).replace("<ld_path>", ld.as_str()),
+    )
+    .unwrap();
+    std::fs::write(ld, get_default_target_ld(is_32bit)).unwrap();
+
     target_path
 }
 
@@ -83,25 +94,32 @@ fn handle_nro_format(root: &Path, artifact: &Artifact, metadata: NroMetadata) {
     let elf = artifact.filenames[0].clone();
     let nro = get_output_elf_path_as(artifact, "nro");
 
-    let romfs = metadata.romfs.as_ref().map(|romfs_dir| RomFs::from_directory(&root.join(romfs_dir)).unwrap());
-    let icon = metadata.icon.as_ref().map(|icon_file| root.join(icon_file.clone())).map(|icon_path| icon_path.to_string_lossy().into_owned());
+    let romfs = metadata
+        .romfs
+        .as_ref()
+        .map(|romfs_dir| RomFs::from_directory(&root.join(romfs_dir)).unwrap());
+    let icon = metadata
+        .icon
+        .as_ref()
+        .map(|icon_file| root.join(icon_file.clone()))
+        .map(|icon_path| icon_path.to_string_lossy().into_owned());
 
     Nxo::from_elf(elf.to_str().unwrap())
-    .unwrap()
-    .write_nro(
-        &mut File::create(nro.clone()).unwrap(),
-        romfs,
-        icon.as_ref().map(|icon_path| icon_path.as_str()),
-        metadata.nacp,
-    )
-    .unwrap();
+        .unwrap()
+        .write_nro(
+            &mut File::create(nro.clone()).unwrap(),
+            romfs,
+            icon.as_deref(),
+            metadata.nacp,
+        )
+        .unwrap();
 
     println!("Built {}", nro.to_string_lossy());
 }
 
 fn handle_nsp_format(root: &Path, artifact: &Artifact, metadata: NspMetadata) {
     let elf = artifact.filenames[0].clone();
-    
+
     let output_path = elf.parent().unwrap();
     let exefs_dir = output_path.join("exefs");
     let _ = std::fs::remove_dir_all(exefs_dir.clone());
@@ -113,22 +131,26 @@ fn handle_nsp_format(root: &Path, artifact: &Artifact, metadata: NspMetadata) {
     let exefs_nsp = get_output_elf_path_as(artifact, "nsp");
 
     let npdm = if let Some(npdm_json) = metadata.npdm_json {
-        let npdm_json_path = root.join(npdm_json.clone());
+        let npdm_json_path = root.join(npdm_json);
         Npdm::from_json(&npdm_json_path).unwrap()
-    }
-    else if let Some(npdm) = metadata.npdm {
+    } else if let Some(npdm) = metadata.npdm {
         npdm
-    }
-    else {
+    } else {
         panic!("No npdm specified")
     };
 
     let mut option = OpenOptions::new();
     let output_option = option.write(true).create(true).truncate(true);
-    let mut out_file = output_option.open(main_npdm.clone()).map_err(|err| (err, main_npdm.clone())).unwrap();
+    let mut out_file = output_option
+        .open(main_npdm.clone())
+        .map_err(|err| (err, main_npdm.clone()))
+        .unwrap();
     npdm.into_npdm(&mut out_file, AcidBehavior::Empty).unwrap();
 
-    Nxo::from_elf(elf.to_str().unwrap()).unwrap().write_nso(&mut File::create(main_exe.clone()).unwrap()).unwrap();
+    Nxo::from_elf(elf.to_str().unwrap())
+        .unwrap()
+        .write_nso(&mut File::create(main_exe).unwrap())
+        .unwrap();
 
     let mut nsp = Pfs0::from_directory(exefs_dir.to_str().unwrap()).unwrap();
     let mut option = OpenOptions::new();
@@ -136,33 +158,18 @@ fn handle_nsp_format(root: &Path, artifact: &Artifact, metadata: NspMetadata) {
     nsp.write_pfs0(
         &mut output_option
             .open(exefs_nsp.clone())
-            .map_err(|err| (err, exefs_nsp.clone())).unwrap(),
+            .map_err(|err| (err, exefs_nsp.clone()))
+            .unwrap(),
     )
-    .map_err(|err| (err, exefs_nsp.clone())).unwrap();
+    .map_err(|err| (err, exefs_nsp.clone()))
+    .unwrap();
 
     println!("Built {}", exefs_nsp.to_string_lossy());
 }
 
-pub fn handle_build(build_cmd: &ArgMatches) {
-    let is_verbose = build_cmd.is_present("verbose");
-
-    let is_release = build_cmd.is_present("release");
-    if is_verbose {
-        println!("Profile: {}", match is_release {
-            true => "release",
-            false => "dev"
-        });
-    }
-
-    let is_32bit = build_cmd.is_present("arm");
-
-    let path = match build_cmd.value_of("path") {
-        Some(path_str) => path_str,
-        None => "."
-    };
-
+pub fn handle_build(args: CargoNxBuild) {
     let metadata = MetadataCommand::new()
-        .manifest_path(Path::new(path).join("Cargo.toml"))
+        .manifest_path(args.path.join("Cargo.toml"))
         .no_deps()
         .exec()
         .unwrap();
@@ -173,49 +180,43 @@ pub fn handle_build(build_cmd: &ArgMatches) {
     let is_nro = metadata_v.pointer("/nx/nro").is_some();
     if is_nsp && is_nro {
         panic!("Error: multiple target formats are not yet supported...");
-    }
-    else if is_nsp {
+    } else if is_nsp {
         println!("Building and generating NSP...");
-    }
-    else if is_nro {
+    } else if is_nro {
         println!("Building and generating NRO...");
-    }
-    else {
+    } else {
         println!("Building...");
     }
 
     let rust_target_path = match env::var("RUST_TARGET_PATH") {
         Ok(s) => PathBuf::from(s),
-        Err(_) => metadata.workspace_root.clone()
+        Err(_) => metadata.workspace_root.clone(),
     };
 
-    let triple = match build_cmd.value_of("triple") {
-        Some(triple_str) => triple_str,
-        None => get_default_target_triple(is_32bit)
-    };
-    if is_verbose {
-        println!("Triple: {}", triple);
+    let triple = args
+        .triple
+        .as_deref()
+        .unwrap_or_else(|| get_default_target_triple(args.arm));
+    println!("Triple: {}", triple);
+
+    if args.verbose {
+        println!("Use custom target: {}", args.use_custom_target);
     }
 
-    let use_default_target = build_cmd.value_of("use-custom-target").is_none();
-    if is_verbose {
-        println!("Use default target: {}", use_default_target);
-    }
-
-    let build_target_path = match use_default_target {
-        true => prepare_default_target(rust_target_path.to_str().unwrap(), is_32bit),
-        false => rust_target_path.to_str().unwrap().into(),
+    let build_target_path = match args.use_custom_target {
+        false => prepare_default_target(rust_target_path.to_str().unwrap(), args.arm),
+        true => rust_target_path.to_str().unwrap().into(),
     };
-    if is_verbose {
+    if args.verbose {
         println!("Build target path: {}", build_target_path);
     }
 
     let mut build_args: Vec<String> = vec![
         String::from("build"),
         format!("--target={}", triple),
-        String::from("--message-format=json-diagnostic-rendered-ansi")
+        String::from("--message-format=json-diagnostic-rendered-ansi"),
     ];
-    if is_release {
+    if args.release {
         build_args.push(String::from("--release"));
     }
 
@@ -223,28 +224,37 @@ pub fn handle_build(build_cmd: &ArgMatches) {
         .args(&build_args)
         .stdout(Stdio::piped())
         .env("RUST_TARGET_PATH", build_target_path)
-        .current_dir(path)
+        .current_dir(&args.path)
         .spawn()
         .unwrap();
-    
+
     let reader = BufReader::new(command.stdout.take().unwrap());
     for message in Message::parse_stream(reader) {
         match message {
             Ok(Message::CompilerArtifact(ref artifact)) => {
-                if artifact.target.kind.contains(&"bin".into()) || artifact.target.kind.contains(&"cdylib".into()) {
-                    let package: &Package = match metadata.packages.iter().find(|v| v.id == artifact.package_id) {
+                if artifact.target.kind.contains(&"bin".into())
+                    || artifact.target.kind.contains(&"cdylib".into())
+                {
+                    let package: &Package = match metadata
+                        .packages
+                        .iter()
+                        .find(|v| v.id == artifact.package_id)
+                    {
                         Some(v) => v,
                         None => continue,
                     };
-    
+
                     let root = package.manifest_path.parent().unwrap();
-    
+
                     if is_nsp {
-                        let nsp_metadata: NspMetadata = serde_json::from_value(metadata_v.pointer("/nx/nsp").cloned().unwrap()).unwrap_or_default();
+                        let nsp_metadata: NspMetadata =
+                            serde_json::from_value(metadata_v.pointer("/nx/nsp").cloned().unwrap())
+                                .unwrap_or_default();
                         handle_nsp_format(root, artifact, nsp_metadata);
-                    }
-                    else if is_nro {
-                        let nro_metadata: NroMetadata = serde_json::from_value(metadata_v.pointer("/nx/nro").cloned().unwrap()).unwrap_or_default();
+                    } else if is_nro {
+                        let nro_metadata: NroMetadata =
+                            serde_json::from_value(metadata_v.pointer("/nx/nro").cloned().unwrap())
+                                .unwrap_or_default();
                         handle_nro_format(root, artifact, nro_metadata);
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,128 +1,19 @@
-extern crate linkle;
-extern crate serde;
-extern crate serde_json;
-extern crate cargo_metadata;
-
 #[macro_use]
 extern crate serde_derive;
-
 #[macro_use]
 extern crate clap;
 
-use std::env;
-use clap::{Arg, AppSettings, App, SubCommand};
-
+mod args;
+mod build;
 mod new;
 
-mod build;
+use self::args::{Cargo, CargoNxSubcommand};
+use clap::Parser;
 
 fn main() {
-    let matches =
-        App::new(crate_name!())
-        .version(concat!("v", crate_version!()))
-        .bin_name("cargo")
-        .setting(AppSettings::SubcommandRequired)
-        .subcommand(SubCommand::with_name("nx")
-            .author(crate_authors!(""))
-            .about(crate_description!())
-            .setting(AppSettings::SubcommandRequired)
-            .subcommand(SubCommand::with_name("new")
-                .arg(
-                    Arg::with_name("path")
-                    .required(true)
-                    .help("New package path")
-                )
-                .arg(
-                    Arg::with_name("name")
-                    .long("name")
-                    .required(false)
-                    .help("Set the new package name (path directory name used by default)")
-                    .takes_value(true)
-                    .value_name("NAME")
-                )
-                .arg(
-                    Arg::with_name("edition")
-                    .long("edition")
-                    .required(false)
-                    .help(format!("Set the Rust edition to use (values: {:?}, default: {})", new::SUPPORTED_EDITIONS, new::DEFAULT_EDITION).as_str())
-                    .takes_value(true)
-                    .value_name("EDITION")
-                )
-                .arg(
-                    Arg::with_name("lib")
-                    .long("lib")
-                    .required(false)
-                    .help("Create a library package")
-                )
-                .arg(
-                    Arg::with_name("nro")
-                    .long("nro")
-                    .required(false)
-                    .help("Create a NRO package (default behavior)")
-                )
-                .arg(
-                    Arg::with_name("nsp")
-                    .long("nsp")
-                    .required(false)
-                    .help("Create a NSP package")
-                )
-                // TODO: author, program ID support (maybe other NPDM/NACP fields?)
-            )
-            .subcommand(SubCommand::with_name("build")
-                .arg(
-                    Arg::with_name("release")
-                    .short("r")
-                    .long("release")
-                    .help("Builds on release profile")
-                    .required(false)
-                )
-                .arg(
-                    Arg::with_name("path")
-                    .short("p")
-                    .long("path")
-                    .takes_value(true)
-                    .value_name("DIR")
-                    .help("Sets a custom path")
-                    .required(false)
-                )
-                .arg(
-                    Arg::with_name("triple")
-                    .short("tp")
-                    .long("triple")
-                    .takes_value(true)
-                    .value_name("TRIPLE")
-                    .help("Sets a custom target triple")
-                    .required(false)
-                )
-                .arg(
-                    Arg::with_name("use-custom-target")
-                    .short("ctg")
-                    .long("use-custom-target")
-                    .help("Avoids using the default target files")
-                    .required(false)
-                )
-                .arg(
-                    Arg::with_name("verbose")
-                    .short("v")
-                    .long("verbose")
-                    .help("Displays extra information during the build process")
-                    .required(false)
-                )
-                .arg( // TODO: better way to do this?
-                    Arg::with_name("arm")
-                    .long("arm")
-                    .required(false)
-                    .help("Compiles as 32-bit default target (64-bit target is used by default)")
-                )
-            )
-        )
-        .get_matches();
-
-    let nx_cmd = matches.subcommand_matches("nx").unwrap();
-    if let Some(new_cmd) = nx_cmd.subcommand_matches("new") {
-        new::handle_new(new_cmd);
-    }
-    else if let Some(build_cmd) = nx_cmd.subcommand_matches("build") {
-        build::handle_build(build_cmd);
+    let Cargo::Nx(args) = Cargo::parse();
+    match args.subcommand {
+        CargoNxSubcommand::New(new_args) => new::handle_new(new_args),
+        CargoNxSubcommand::Build(build_args) => build::handle_build(build_args),
     }
 }


### PR DESCRIPTION
This updates cargo-nx to use Clap 3, defining the arguments using derives, and also ups the Rust edition to 2021 because why not.

Some slight argument changes: 
 - `cargo nx new --nro`, `cargo nx new --lib`, and `cargo nx new --nsp` no longer exist. Instead, they've been unified under `cargo nx new --type [type]`, such as `cargo nx new --type nsp`, which makes more sense, as they're mutually exclusive anyways.
 - Clap 3 only takes a single `char` for short command forms, so two arguments were changed:
   - `-tp` -> `-t`
   - `-ctg` -> `-c`