### PR TITLE
chore(ci): add github actions CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: ci
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1
+        with:
+          components: clippy
+          cache: false
+          rustflags: ''
+
+      - name: Cache rust build files
+        uses: Leafwing-Studios/cargo-cache@a0709d80dd96c8734ac8f186c1f238c8f528d198 # v2
+
+      ## Build
+      - name: check (release)
+        run: cargo check --all-features --release
+
+      - name: clippy
+        run: cargo clippy --all-features -- -D warnings --force-warn deprecated --force-warn dead-code
+
+      ## Test
+      - name: unit-tests
+        run: cargo test --all-features
+
+      - name: doc-tests
+        run: cargo test --all-features --doc
+
+  format:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@11df97af8e8102fd60b60a77dfbf58d40cd843b8 # v1
+        with:
+          toolchain: nightly
+          components: rustfmt
+          cache: false
+
+      - run: cargo +nightly fmt --all -- --check


### PR DESCRIPTION
This pull request introduces a new continuous integration (CI) workflow for Rust projects. The workflow is defined in the `.github/workflows/ci.yml` file and includes jobs for building, testing, and formatting the code.

Key changes include:

* **CI Workflow Setup**:
  * Added a CI workflow triggered on pull requests and pushes to the `main` branch.
  * Configured environment variables for Rust, including `CARGO_TERM_COLOR` and `RUST_BACKTRACE`.

* **Build and Test Jobs**:
  * Defined a `test` job that runs on `ubuntu-latest`, checks out the repository, sets up the Rust toolchain, caches build files, and runs build and test commands (`cargo check`, `cargo clippy`, `cargo test`).
  * Included steps for running unit tests and documentation tests.

* **Formatting Job**:
  * Added a `format` job that also runs on `ubuntu-latest`, checks out the repository, sets up the Rust toolchain with `rustfmt`, and checks code formatting using `cargo fmt`.