### PR TITLE
Add a flag to build overlays directly with the 'ovl' extension.

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -168,6 +168,7 @@ struct NroMetadata {
     romfs: Option<String>,
     icon: Option<String>,
     nacp: Option<Nacp>,
+    overlay: Option<bool>
 }
 
 fn get_output_elf_path_as(artifact: &Artifact, extension: &str) -> PathBuf {
@@ -178,7 +179,7 @@ fn get_output_elf_path_as(artifact: &Artifact, extension: &str) -> PathBuf {
 
 fn handle_nro_format(root: &Path, artifact: &Artifact, metadata: NroMetadata) {
     let elf = artifact.filenames[0].clone();
-    let nro = get_output_elf_path_as(artifact, "nro");
+    let nro = get_output_elf_path_as(artifact, if metadata.overlay == Some(true) { "ovl" } else { "nro" });
 
     let romfs = metadata
         .romfs


### PR DESCRIPTION
This adds an `overlay` flag to the nro metadata definition indicating that the built binary should be renamed with the `ovl` format for use with `nx-ovlloader`.